### PR TITLE
Add browser demo for Song Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# music-agent
+# Song Agent – Sing to Sheet Music
+
+A browser-based AI demo where you can hum a short melody and immediately get:
+
+- The detected pitch sequence shown as note names
+- Simplified sheet music rendered with VexFlow
+- Playback of the melody with Tone.js
+- An LLM interpretation that explains the most likely key, suggested chords, and stylistic notes
+
+This project demonstrates how an agent can coordinate live audio analysis, symbolic music rendering, playback, and large language model reasoning to produce a cohesive experience.
+
+## Features
+
+- **Live audio capture** using the Web Audio API (5–10 seconds at a time).
+- **Pitch detection** with [Pitchy](https://github.com/charlieroberts/pitchy) to map dominant frequencies to MIDI notes.
+- **Sheet music rendering** with VexFlow, quantized as quarter notes for an easy-to-read staff.
+- **Playback** of the detected melody using Tone.js.
+- **LLM explanation** via OpenAI's Chat Completions API (with an offline heuristic fallback when no key is supplied).
+
+## Running the demo
+
+Open `index.html` in a modern browser (Chrome, Edge, or Safari). Because the demo requests microphone access, you will need to serve the files via `https://` or from `http://localhost`.
+
+A simple way to do this is to use a local static server, e.g.:
+
+```bash
+npx serve .
+```
+
+Then navigate to the provided `localhost` URL.
+
+## Usage
+
+1. Click **Record** and hum a simple melody for up to 10 seconds.
+2. Click **Stop** to finalize capture. The detected notes, sheet music, and playback controls will become active.
+3. (Optional) Paste an OpenAI API key and click **Analyze Melody** to get an LLM-generated explanation. Without a key the app uses a deterministic heuristic to provide a sample response.
+4. Press **Play Melody** to hear the quantized playback of your tune.
+
+## Notes and limitations
+
+- The pitch detector is tuned for monophonic input and may misinterpret noisy environments or complex harmonies.
+- Durations are simplified to a steady pulse so the sheet music is readable without rhythm transcription.
+- API calls are client-side only; keep your key private and be mindful of usage costs.
+- If microphone access fails, try using the site over HTTPS or fall back to a pre-recorded audio file (not included in this demo).
+
+## License
+
+MIT

--- a/index.html
+++ b/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Song Agent – Sing to Sheet Music</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="header">
+      <h1>Song Agent</h1>
+      <p class="tagline">Sing or hum, get instant sheet music and musical insights.</p>
+    </header>
+
+    <main class="layout">
+      <section class="controls">
+        <div class="card">
+          <h2>Record</h2>
+          <p>
+            Capture a 5–10 second snippet of your melody. The agent will detect the
+            dominant pitch every half second and simplify it into a monophonic line.
+          </p>
+          <div class="button-row">
+            <button id="recordButton" class="primary">Record</button>
+            <button id="stopButton" class="secondary" disabled>Stop</button>
+          </div>
+          <p id="status" class="status">Ready to record.</p>
+        </div>
+
+        <div class="card">
+          <h2>LLM Explanation</h2>
+          <p>
+            Provide an OpenAI API key (optional). Without a key the app will use a
+            local heuristic to generate a mock explanation.
+          </p>
+          <label class="label" for="apiKey">OpenAI API Key</label>
+          <input id="apiKey" type="password" placeholder="sk-..." />
+          <button id="analyzeButton" class="primary" disabled>Analyze Melody</button>
+        </div>
+
+        <div class="card">
+          <h2>Playback</h2>
+          <p>Preview the detected melody rendered with Tone.js.</p>
+          <button id="playButton" class="primary" disabled>Play Melody</button>
+        </div>
+      </section>
+
+      <section class="results">
+        <div class="card">
+          <h2>Detected Notes</h2>
+          <p id="noteList" class="note-list">Record to see detected notes.</p>
+        </div>
+
+        <div class="card">
+          <h2>Sheet Music</h2>
+          <div id="sheetContainer" class="sheet-container">
+            <svg id="sheet" role="img" aria-label="Rendered sheet music"></svg>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>LLM Output</h2>
+          <pre id="llmJson" class="json-output">{"status": "Waiting for analysis"}</pre>
+          <p id="llmExplanation" class="llm-explanation">
+            The explanation will appear here after analysis.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>
+        Built with Web Audio, Pitchy, VexFlow, Tone.js, and an LLM to showcase a
+        tool-using music agent.
+      </p>
+    </footer>
+
+    <script type="module" src="main.js"></script>
+  </body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,336 @@
+import { Factory } from "https://cdn.jsdelivr.net/npm/vexflow@4.2.4/build/esm/vexflow.js";
+import * as Tone from "https://cdn.jsdelivr.net/npm/tone@14.8.55/build/Tone.js";
+import { PitchDetector } from "https://cdn.jsdelivr.net/npm/pitchy@4.0.0/dist/index.esm.js";
+
+const recordButton = document.getElementById("recordButton");
+const stopButton = document.getElementById("stopButton");
+const statusEl = document.getElementById("status");
+const noteListEl = document.getElementById("noteList");
+const playButton = document.getElementById("playButton");
+const analyzeButton = document.getElementById("analyzeButton");
+const apiKeyInput = document.getElementById("apiKey");
+const llmJsonEl = document.getElementById("llmJson");
+const llmExplanationEl = document.getElementById("llmExplanation");
+
+let audioContext;
+let analyserNode;
+let mediaStream;
+let detector;
+let dataArray;
+let detectionInterval;
+let recordingStartTime = 0;
+
+const collectedNotes = [];
+const noteNames = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+
+recordButton.addEventListener("click", startRecording);
+stopButton.addEventListener("click", stopRecording);
+playButton.addEventListener("click", playMelody);
+analyzeButton.addEventListener("click", analyzeMelodyWithLLM);
+
+function resetState() {
+  collectedNotes.length = 0;
+  noteListEl.textContent = "Listening...";
+  playButton.disabled = true;
+  analyzeButton.disabled = true;
+  clearSheetMusic();
+  llmJsonEl.textContent = '{"status": "Waiting for analysis"}';
+  llmExplanationEl.textContent = "The explanation will appear here after analysis.";
+}
+
+async function startRecording() {
+  if (detectionInterval) {
+    clearInterval(detectionInterval);
+  }
+
+  resetState();
+
+  try {
+    mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  } catch (error) {
+    console.error(error);
+    statusEl.textContent = "Microphone access denied. Please allow mic permissions.";
+    return;
+  }
+
+  audioContext = new (window.AudioContext || window.webkitAudioContext)();
+  analyserNode = audioContext.createAnalyser();
+  analyserNode.fftSize = 2048;
+
+  const source = audioContext.createMediaStreamSource(mediaStream);
+  source.connect(analyserNode);
+
+  detector = PitchDetector.forFloat32Array(analyserNode.fftSize);
+  dataArray = new Float32Array(analyserNode.fftSize);
+  recordingStartTime = audioContext.currentTime;
+
+  recordButton.disabled = true;
+  stopButton.disabled = false;
+  statusEl.textContent = "Recording... hum for up to 10 seconds.";
+
+  detectionInterval = setInterval(() => {
+    analyserNode.getFloatTimeDomainData(dataArray);
+    const [pitch, clarity] = detector.findPitch(dataArray, audioContext.sampleRate);
+
+    if (!pitch || Number.isNaN(pitch) || pitch < 60 || pitch > 1400) {
+      return;
+    }
+
+    if (clarity < 0.9) {
+      return;
+    }
+
+    const midi = Math.round(12 * Math.log2(pitch / 440) + 69);
+    const { name, octave } = midiToNote(midi);
+    const timestamp = audioContext.currentTime - recordingStartTime;
+
+    const previous = collectedNotes[collectedNotes.length - 1];
+    if (!previous || previous.midi !== midi) {
+      collectedNotes.push({
+        midi,
+        name,
+        octave,
+        frequency: pitch,
+        timestamp,
+      });
+      renderNoteList();
+    }
+  }, 250);
+}
+
+function stopRecording() {
+  if (!mediaStream) {
+    return;
+  }
+
+  if (detectionInterval) {
+    clearInterval(detectionInterval);
+    detectionInterval = null;
+  }
+
+  mediaStream.getTracks().forEach((track) => track.stop());
+  mediaStream = null;
+
+  if (audioContext && audioContext.state !== "closed") {
+    audioContext.close();
+  }
+
+  stopButton.disabled = true;
+  recordButton.disabled = false;
+
+  if (collectedNotes.length === 0) {
+    statusEl.textContent = "No pitch detected. Try again in a quieter room.";
+    noteListEl.textContent = "No notes captured.";
+    return;
+  }
+
+  statusEl.textContent = "Recording stopped. Review the detected melody.";
+  playButton.disabled = false;
+  analyzeButton.disabled = false;
+
+  renderSheetMusic(collectedNotes);
+}
+
+function renderNoteList() {
+  if (collectedNotes.length === 0) {
+    noteListEl.textContent = "Listening...";
+    return;
+  }
+
+  const display = collectedNotes
+    .map((note) => `${note.name}${note.octave}`)
+    .join(" • ");
+  noteListEl.textContent = display;
+}
+
+function clearSheetMusic() {
+  const sheet = document.getElementById("sheet");
+  if (sheet) {
+    sheet.innerHTML = "";
+  }
+}
+
+function renderSheetMusic(sequence) {
+  clearSheetMusic();
+
+  const sheet = document.getElementById("sheet");
+  if (!sheet) return;
+
+  if (!sequence.length) {
+    return;
+  }
+
+  const width = Math.max(360, sequence.length * 70);
+  const height = 200;
+
+  const factory = new Factory({ renderer: { elementId: "sheet", width, height } });
+  const score = factory.EasyScore();
+  const system = factory.System();
+
+  const vexNotes = sequence
+    .map((note) => {
+      const key = toVexKey(note.name, note.octave);
+      return `${key}/q`;
+    })
+    .join(", ");
+
+  system
+    .addStave({
+      voices: [
+        score.voice(
+          score.notes(vexNotes || "b/4/q", {
+            stem: "up",
+          })
+        ),
+      ],
+    })
+    .addClef("treble")
+    .addTimeSignature("4/4");
+
+  factory.draw();
+}
+
+async function playMelody() {
+  if (!collectedNotes.length) {
+    return;
+  }
+
+  await Tone.start();
+  const synth = new Tone.Synth().toDestination();
+  const now = Tone.now();
+  const step = 0.5;
+
+  collectedNotes.forEach((note, index) => {
+    const toneNote = `${note.name.replace("#", "#")}${note.octave}`;
+    synth.triggerAttackRelease(toneNote, "8n", now + index * step);
+  });
+}
+
+async function analyzeMelodyWithLLM() {
+  if (!collectedNotes.length) {
+    return;
+  }
+
+  analyzeButton.disabled = true;
+  llmJsonEl.textContent = "Analyzing...";
+  llmExplanationEl.textContent = "Contacting the language model...";
+
+  const apiKey = apiKeyInput.value.trim();
+  const noteSequence = collectedNotes.map((note) => `${note.name}${note.octave}`);
+
+  let responsePayload;
+
+  if (!apiKey) {
+    responsePayload = heuristicLLMResponse(noteSequence);
+  } else {
+    try {
+      responsePayload = await callOpenAI(apiKey, noteSequence);
+    } catch (error) {
+      console.error(error);
+      statusEl.textContent = "LLM call failed, using local heuristic.";
+      responsePayload = heuristicLLMResponse(noteSequence);
+    }
+  }
+
+  llmJsonEl.textContent = JSON.stringify(responsePayload, null, 2);
+  llmExplanationEl.textContent = responsePayload.explanation;
+  analyzeButton.disabled = false;
+}
+
+function heuristicLLMResponse(notes) {
+  if (!notes.length) {
+    return {
+      likely_key: "C major",
+      style: "ambient",
+      suggested_chords: ["C", "F", "G"],
+      explanation: "No notes captured, defaulting to C major as a safe guess.",
+    };
+  }
+
+  const pitchCounts = new Map();
+  notes.forEach((note) => {
+    const pitchClass = note.replace(/\d+/g, "");
+    pitchCounts.set(pitchClass, (pitchCounts.get(pitchClass) || 0) + 1);
+  });
+
+  let dominantPitch = "C";
+  let maxCount = 0;
+  for (const [pitch, count] of pitchCounts.entries()) {
+    if (count > maxCount) {
+      dominantPitch = pitch;
+      maxCount = count;
+    }
+  }
+
+  const possibleKeys = {
+    C: { key: "C major", chords: ["C", "F", "G", "Am"], style: "folk/pop" },
+    G: { key: "G major", chords: ["G", "C", "D", "Em"], style: "bluegrass" },
+    D: { key: "D major", chords: ["D", "G", "A", "Bm"], style: "rock" },
+    A: { key: "A major", chords: ["A", "D", "E", "F#m"], style: "country" },
+    E: { key: "E minor", chords: ["Em", "C", "D", "G"], style: "indie" },
+    F: { key: "F major", chords: ["F", "Bb", "C", "Dm"], style: "ballad" },
+  };
+
+  const match = possibleKeys[dominantPitch] || possibleKeys.C;
+
+  return {
+    likely_key: match.key,
+    style: match.style,
+    suggested_chords: match.chords,
+    explanation: `Your melody emphasizes ${dominantPitch}, so ${match.key} is a natural fit with ${match.chords.join(", ")}.`,
+  };
+}
+
+async function callOpenAI(apiKey, noteSequence) {
+  const prompt = `Given the note sequence ${JSON.stringify(
+    noteSequence
+  )}, determine the most likely musical key. Suggest a style this fits in, and possible chords to harmonize. Respond with JSON containing keys: likely_key, style, suggested_chords (array), and explanation.`;
+
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      temperature: 0.4,
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are a helpful music theory assistant. Always respond with valid JSON.",
+        },
+        {
+          role: "user",
+          content: prompt,
+        },
+      ],
+      response_format: { type: "json_object" },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`OpenAI API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+
+  if (!data.choices?.length) {
+    throw new Error("No choices returned from OpenAI API");
+  }
+
+  const parsed = JSON.parse(data.choices[0].message.content);
+  return parsed;
+}
+
+function midiToNote(midi) {
+  const safeMidi = Math.min(Math.max(midi, 0), 127);
+  const name = noteNames[safeMidi % 12];
+  const octave = Math.floor(safeMidi / 12) - 1;
+  return { name, octave };
+}
+
+function toVexKey(name, octave) {
+  return `${name.toLowerCase().replace("#", "#")}/${octave}`;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,195 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  padding: 2rem clamp(1rem, 5vw, 4rem);
+  background: linear-gradient(135deg, #1e293b, #0f172a 55%, #1e293b);
+  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.8);
+}
+
+.header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(2rem, 5vw, 3rem);
+}
+
+.tagline {
+  margin: 0;
+  font-size: clamp(1rem, 3vw, 1.25rem);
+  opacity: 0.85;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  padding: clamp(1rem, 5vw, 3rem);
+  flex: 1;
+  background: radial-gradient(circle at top, rgba(148, 163, 184, 0.15), transparent 50%),
+    #0f172a;
+}
+
+.controls,
+.results {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 1.5rem;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
+  transition: transform 0.2s ease, border 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(94, 234, 212, 0.4);
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 1.3rem;
+}
+
+p {
+  line-height: 1.6;
+  margin-top: 0;
+}
+
+.button-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+button {
+  font: inherit;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button.primary {
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  color: #0f172a;
+  box-shadow: 0 15px 30px rgba(56, 189, 248, 0.35);
+}
+
+button.secondary {
+  background: rgba(148, 163, 184, 0.2);
+  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none !important;
+}
+
+button:not(:disabled):hover {
+  transform: translateY(-1px) scale(1.01);
+  box-shadow: 0 20px 35px rgba(129, 140, 248, 0.4);
+}
+
+.status {
+  margin-top: 1rem;
+  font-weight: 500;
+  color: #93c5fd;
+}
+
+.label {
+  display: block;
+  margin: 0.75rem 0 0.5rem;
+  font-weight: 600;
+}
+
+input {
+  width: 100%;
+  padding: 0.65rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.7);
+  color: inherit;
+  font: inherit;
+}
+
+.note-list {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.95rem;
+  background: rgba(15, 23, 42, 0.65);
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  min-height: 3rem;
+}
+
+.sheet-container {
+  min-height: 180px;
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.sheet-container svg {
+  width: 100%;
+  height: auto;
+}
+
+.json-output {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.9rem;
+}
+
+.llm-explanation {
+  margin-top: 1rem;
+  font-style: italic;
+  color: #f9a8d4;
+}
+
+.footer {
+  padding: 1.5rem;
+  text-align: center;
+  font-size: 0.9rem;
+  background: rgba(15, 23, 42, 0.9);
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+@media (max-width: 768px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .card {
+    padding: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add Song Agent single-page demo that records audio, detects pitches, and renders sheet music
- implement Tone.js playback and optional OpenAI-powered analysis with a heuristic fallback
- style the experience with a responsive glassmorphism-inspired layout and document usage in the README

## Testing
- not run (static web app)


------
https://chatgpt.com/codex/tasks/task_e_68d4b932e1d083209c3a671e455e9f4b